### PR TITLE
Adding new color scheme structure

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,11 +3,13 @@ module.exports = {
   // https://tailwindcss.com/docs/just-in-time-mode
   // mode: "jit",
   theme: {
-    colors: {
-      'purple': '#4B3869',
-      'light-purple': '#664E88',
-      'aqua': '#63B4B8',
-      'light-aqua': '#A9E4D7',
+    extend: {
+      colors: {
+        'purple': '#4B3869',
+        'light-purple': '#664E88',
+        'aqua': '#63B4B8',
+        'light-aqua': '#A9E4D7',
+      },
     },
   },
   variants: {},


### PR DESCRIPTION
Just correcting color overwriting by adding color scheme with the `extend: {},` structure. Closes #8.